### PR TITLE
use rust-gmp from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.3"
 num-traits = "0.1"
 ramp = { git="https://github.com/snipsco/ramp.git", optional=true }
 num = { version="0.1", optional=true }
-rust-gmp = { git="https://github.com/fizyk20/rust-gmp.git", optional=true }
+rust-gmp = { version="0.4", optional=true }
 primal = { version="0.2", optional=true }
 
 [dev-dependencies]


### PR DESCRIPTION
new release of rust-gmp to crates.io, allowing us to use that instead of github repo