### PR TITLE
switch to secure version of GMP powm

### DIFF
--- a/src/arithimpl/gmpimpl.rs
+++ b/src/arithimpl/gmpimpl.rs
@@ -41,7 +41,7 @@ pub use num_traits::{Zero, One};
 
 impl ModPow for Mpz {
     fn modpow(base: &Self, exponent: &Self, modulus: &Self) -> Self {
-        base.powm(exponent, modulus)
+        base.powm_sec(exponent, modulus)
     }
 }
 


### PR DESCRIPTION
Pending next release of `rust-gmp`.

Would be interesting to measure performance differences as well.